### PR TITLE
Convert to package

### DIFF
--- a/loki_jsonschema_resolver/__init__.py
+++ b/loki_jsonschema_resolver/__init__.py
@@ -1,0 +1,1 @@
+from .ref_resolver import resolve_references  # noqa: F401

--- a/loki_jsonschema_resolver/ref_resolver.py
+++ b/loki_jsonschema_resolver/ref_resolver.py
@@ -582,7 +582,7 @@ def resolve_references(target_path: str) -> None:
                         deferred_files.pop(index)
 
 
-if __name__ == "__main__":
+def main() -> None:
     parser = argparse.ArgumentParser(description="CLI Tool")
     parser.add_argument(
         "-t",
@@ -632,3 +632,7 @@ if __name__ == "__main__":
             save_dict_to_json(dictionary=data, file_path=file_path)
     else:
         resolve_references(args.target_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 description = "A ref resolver for Json Schema files."
 authors = [{ name = "Chachi Pereira", email = "hangs_sedans_09@icloud.com" }]
 readme = "README.md"
-license = "MIT"
+license = {text = "MIT License"}
 
 [project.urls]
 Source = "https://github.com/lokireturns/loki_jsonschema_resolver"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+
+[project]
+name = "loki_jsonschema_resolver"
+version = "0.1.0"
+description = "A ref resolver for Json Schema files."
+authors = [{ name = "Chachi Pereira", email = "hangs_sedans_09@icloud.com" }]
+readme = "README.md"
+license = "MIT"
+
+[project.urls]
+Source = "https://github.com/lokireturns/loki_jsonschema_resolver"
+
+[project.scripts]
+fruit-cli = 'loki_jsonschema_resolver.ref_resolver:main'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,4 @@ license = {text = "MIT License"}
 Source = "https://github.com/lokireturns/loki_jsonschema_resolver"
 
 [project.scripts]
-fruit-cli = 'loki_jsonschema_resolver.ref_resolver:main'
+loki-jsonschema-resolver-cli = 'loki_jsonschema_resolver.ref_resolver:main'

--- a/tests/test_ref_resolver.py
+++ b/tests/test_ref_resolver.py
@@ -1,6 +1,11 @@
 import pytest
 
-from main import SchemaRefType, evaluate_ref, fetch_value_from_ref, walk_dictionary
+from loki_jsonschema_resolver.ref_resolver import (
+    SchemaRefType,
+    evaluate_ref,
+    fetch_value_from_ref,
+    walk_dictionary,
+)
 
 
 def test_evaluate_ref() -> None:


### PR DESCRIPTION
Convert the repo to a Python package installable directly from GitHub using pip's support for VCS (Version Control System) URLs 

`e.g. pip install git+https://github.com/lokireturns/loki_jsonschema_resolver.git  `